### PR TITLE
feat: eslint cache

### DIFF
--- a/packages/projen/component/linting/.projen/tasks.json
+++ b/packages/projen/component/linting/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/linting/src/linting.ts
+++ b/packages/projen/component/linting/src/linting.ts
@@ -1,5 +1,5 @@
-import { applyOverrides } from '@arroyodev-llc/utils.projen'
-import { Component, type ObjectFile, type Project } from 'projen'
+import { applyOverrides, replaceTask } from '@arroyodev-llc/utils.projen'
+import { Component, type ObjectFile, type Project, type TaskStep } from 'projen'
 import {
 	type NodeProject,
 	type PrettierOptions,
@@ -60,5 +60,27 @@ export class LintConfig extends Component {
 		})
 
 		this.eslintFile = project.tryFindObjectFile('.eslintrc.json')!
+	}
+
+	/**
+	 * Merge task step into eslint task.
+	 * @param step Task step to merge.
+	 */
+	updateEslintTask(step: TaskStep): this {
+		replaceTask(this.project, 'eslint', [step])
+		return this
+	}
+
+	/**
+	 * Replace eslint executable command.
+	 * @param exec Replacement value.
+	 * @param replace Existing value to replace. Defaults to 'eslint'.
+	 */
+	setEslintExec(exec: string, replace: string = 'eslint'): this {
+		const eslintTask = this.project.tasks.tryFind('eslint')!
+		const eslintCmd = eslintTask.steps[0].exec!.replace(replace, exec)
+		return this.updateEslintTask({
+			exec: eslintCmd,
+		})
 	}
 }

--- a/packages/projen/component/pnpm-workspace/.projen/tasks.json
+++ b/packages/projen/component/pnpm-workspace/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/release-please/.projen/tasks.json
+++ b/packages/projen/component/release-please/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/typescript-source-file/.projen/tasks.json
+++ b/packages/projen/component/typescript-source-file/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/unbuild/.projen/tasks.json
+++ b/packages/projen/component/unbuild/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/vite/.projen/tasks.json
+++ b/packages/projen/component/vite/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/vitest/.projen/tasks.json
+++ b/packages/projen/component/vitest/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/vue/.projen/tasks.json
+++ b/packages/projen/component/vue/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/projen/component/vue/src/vue.ts
+++ b/packages/projen/component/vue/src/vue.ts
@@ -84,9 +84,7 @@ export class Vue extends Component {
 			'parserOptions.extraFileExtensions': ['.vue'],
 			'settings.import/parsers.vue-eslint-parser': ['.vue'],
 		})
-		component.eslint.eslintTask.reset(
-			component.eslint.eslintTask.steps[0]!.exec!.replace('.tsx', '.tsx,.vue')
-		)
+		component.setEslintExec('.tsx,.vue', '.tsx')
 		return this
 	}
 

--- a/packages/utils/projen/.projen/tasks.json
+++ b/packages/utils/projen/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/vue/ui/button/.projen/tasks.json
+++ b/packages/vue/ui/button/.projen/tasks.json
@@ -62,7 +62,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx,.vue --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx,.vue --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/packages/vue/ui/text/.projen/tasks.json
+++ b/packages/vue/ui/text/.projen/tasks.json
@@ -62,7 +62,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx,.vue --fix --no-error-on-unmatched-pattern src test build-tools"
+          "exec": "eslint --cache --ext .ts,.tsx,.vue --fix --no-error-on-unmatched-pattern src test build-tools"
         }
       ]
     },

--- a/projenrc/project.ts
+++ b/projenrc/project.ts
@@ -317,7 +317,7 @@ export class TypescriptProject extends typescript.TypeScriptProject {
 		this.package.addField('sideEffects', false)
 		new LintConfig(this)
 
-		this.applyBundler().applyGithub()
+		this.applyLintConfig().applyBundler().applyGithub()
 	}
 
 	protected applyBundler(): this {
@@ -355,11 +355,12 @@ export class TypescriptProject extends typescript.TypeScriptProject {
 		}
 	}
 
-	addWorkspaceDeps(...dependency: (javascript.NodeProject | string)[]) {
-		return PnpmWorkspace.of(this)!.addWorkspaceDeps(...dependency)
+	protected applyLintConfig(): this {
+		LintConfig.of(this)!.setEslintExec('eslint --cache')
+		return this
 	}
 
-	applyGithub(): this {
+	protected applyGithub(): this {
 		let releasePlease =
 			ReleasePlease.of(this.parent ?? this) ?? new ReleasePlease(this)
 		releasePlease.addProject(this, { releaseType: ReleaseType.NODE })
@@ -370,6 +371,10 @@ export class TypescriptProject extends typescript.TypeScriptProject {
 			releasePlease.addProject(this, { releaseType: ReleaseType.NODE }, '0.0.0')
 		}
 		return this
+	}
+
+	addWorkspaceDeps(...dependency: (javascript.NodeProject | string)[]) {
+		return PnpmWorkspace.of(this)!.addWorkspaceDeps(...dependency)
 	}
 }
 


### PR DESCRIPTION
- feat(utils.projen): `replaceTask` utility.
- feat(projen.components.linting): define `updateEslintTask`, `setEslintExec` public methods.
- feat(projen.components.vue): utilize `LintConfig.setEslintExec` to add vue ext
- feat(projen): enable eslint cache for all ts projects.
- chore(projen): update all managed task manifets.

Fixes #
