### PR TITLE
feat: Deep merge nx-monorepo options, remove vue duplicate build step

### DIFF
--- a/packages/projen/component/vue/src/vue.ts
+++ b/packages/projen/component/vue/src/vue.ts
@@ -90,7 +90,6 @@ export class Vue extends Component {
 
 	applyUnBuild(component?: UnBuild): this {
 		if (!component) return this
-		this.project.compileTask.exec('unbuild')
 		this.project.deps.addDependency('rollup', DependencyType.BUILD)
 		this.project.deps.addDependency('rollup-plugin-vue', DependencyType.BUILD)
 		component.file.addImport({

--- a/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
@@ -15,6 +15,7 @@ import {
 } from 'projen'
 import { secretToString } from 'projen/lib/github/util'
 import { NodePackage, TypeScriptModuleResolution } from 'projen/lib/javascript'
+import { deepMerge } from 'projen/lib/util'
 import type { NxMonorepoProjectOptions } from './nx-monorepo-project-options'
 
 const arroyoBot = github.GithubCredentials.fromApp({
@@ -22,8 +23,9 @@ const arroyoBot = github.GithubCredentials.fromApp({
 	privateKeySecret: 'AD_BOT_PRIVATE_KEY',
 })
 
-const projectDefaults = {
+export const CONFIG_DEFAULTS = {
 	name: '',
+	defaultReleaseBranch: 'main',
 	packageManager: javascript.NodePackageManager.PNPM,
 	pnpmVersion: '8',
 	npmAccess: javascript.NpmAccess.PUBLIC,
@@ -85,12 +87,15 @@ export class MonorepoProject extends NxMonorepoProject {
 
 	constructor(options: NxMonorepoProjectOptions) {
 		const { workspaceDeps, tsconfigBase, tsconfig, ...rest } = options
+		const mergedOptions = deepMerge(
+			[Object.assign({}, CONFIG_DEFAULTS), rest],
+			true
+		) as NxMonorepoProjectOptions
 		super({
 			defaultReleaseBranch: 'main',
-			...projectDefaults,
+			...mergedOptions,
 			releaseToNpm: false,
 			projenDevDependency: true,
-			...rest,
 		})
 		this.pnpm = new PnpmWorkspace(this)
 		this.pnpm.addWorkspaceDeps(...(workspaceDeps ?? []))

--- a/packages/vue/ui/button/.projen/tasks.json
+++ b/packages/vue/ui/button/.projen/tasks.json
@@ -58,9 +58,6 @@
           "args": [
             "--build"
           ]
-        },
-        {
-          "exec": "unbuild"
         }
       ]
     },

--- a/packages/vue/ui/text/.projen/tasks.json
+++ b/packages/vue/ui/text/.projen/tasks.json
@@ -58,9 +58,6 @@
           "args": [
             "--build"
           ]
-        },
-        {
-          "exec": "unbuild"
         }
       ]
     },


### PR DESCRIPTION
- feat(projen.project.nx-monorepo): export defaults, deep merge options.
- fix(projen.component.vue): remove duplicative unbuild step

Fixes #
