### PR TITLE
fix(projen.component.vue): disable eslint rules that conflict with prettier.

### DIFF
--- a/packages/projen/component/vue/src/vue.ts
+++ b/packages/projen/component/vue/src/vue.ts
@@ -75,7 +75,19 @@ export class Vue extends Component {
 		component.eslint.addOverride({
 			files: ['*.vue', '**/*.vue'],
 			rules: {
+				// disable rules that conflict with prettier.
 				'vue/html-indent': ['off'],
+				'vue/multiline-html-element-content-newline': ['off'],
+				'vue/html-closing-bracket-newline': ['off'],
+				'vue/html-closing-bracket-spacing': ['off'],
+				'vue/html-end-tags': ['off'],
+				'vue/html-quotes': ['off'],
+				'vue/max-attributes-per-line': ['off'],
+				'vue/mustache-interpolation-spacing': ['off'],
+				'vue/no-multi-spaces': ['off'],
+				'vue/no-spaces-around-equal-signs-in-attribute': ['off'],
+				'vue/singleline-html-element-content-newline': ['off'],
+				'vue/html-self-closing': ['off'],
 			},
 		})
 		applyOverrides(component.eslintFile, {

--- a/packages/vue/ui/button/.eslintrc.json
+++ b/packages/vue/ui/button/.eslintrc.json
@@ -173,6 +173,39 @@
       "rules": {
         "vue/html-indent": [
           "off"
+        ],
+        "vue/multiline-html-element-content-newline": [
+          "off"
+        ],
+        "vue/html-closing-bracket-newline": [
+          "off"
+        ],
+        "vue/html-closing-bracket-spacing": [
+          "off"
+        ],
+        "vue/html-end-tags": [
+          "off"
+        ],
+        "vue/html-quotes": [
+          "off"
+        ],
+        "vue/max-attributes-per-line": [
+          "off"
+        ],
+        "vue/mustache-interpolation-spacing": [
+          "off"
+        ],
+        "vue/no-multi-spaces": [
+          "off"
+        ],
+        "vue/no-spaces-around-equal-signs-in-attribute": [
+          "off"
+        ],
+        "vue/singleline-html-element-content-newline": [
+          "off"
+        ],
+        "vue/html-self-closing": [
+          "off"
         ]
       }
     },

--- a/packages/vue/ui/text/.eslintrc.json
+++ b/packages/vue/ui/text/.eslintrc.json
@@ -173,6 +173,39 @@
       "rules": {
         "vue/html-indent": [
           "off"
+        ],
+        "vue/multiline-html-element-content-newline": [
+          "off"
+        ],
+        "vue/html-closing-bracket-newline": [
+          "off"
+        ],
+        "vue/html-closing-bracket-spacing": [
+          "off"
+        ],
+        "vue/html-end-tags": [
+          "off"
+        ],
+        "vue/html-quotes": [
+          "off"
+        ],
+        "vue/max-attributes-per-line": [
+          "off"
+        ],
+        "vue/mustache-interpolation-spacing": [
+          "off"
+        ],
+        "vue/no-multi-spaces": [
+          "off"
+        ],
+        "vue/no-spaces-around-equal-signs-in-attribute": [
+          "off"
+        ],
+        "vue/singleline-html-element-content-newline": [
+          "off"
+        ],
+        "vue/html-self-closing": [
+          "off"
         ]
       }
     },


### PR DESCRIPTION
- fix(projen.component.vue): disable vue eslint rules that conflict with prettier.
- style: update managed eslint files

Fixes #
