### PR TITLE
fix(projen.project.nx-monorepo): resolve subproject dependencies, related fixes

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -44,10 +44,6 @@
       "type": "build"
     },
     {
-      "name": "eslint_d",
-      "type": "build"
-    },
-    {
       "name": "eslint-config-prettier",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -260,7 +260,7 @@
           "exec": "pnpm exec syncpack fix-mismatches"
         },
         {
-          "exec": "pnpm install"
+          "exec": "pnpm exec projen install"
         },
         {
           "exec": "pnpm exec projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,8 +1,5 @@
 import { LintConfig } from '@arroyodev-llc/projen.component.linting'
-import {
-	Vitest,
-	VitestConfigType,
-} from '@arroyodev-llc/projen.component.vitest'
+import { Vitest } from '@arroyodev-llc/projen.component.vitest'
 import { TypescriptProject } from '@arroyodev-llc/projen.project.typescript'
 import { VueComponentProject } from '@arroyodev-llc/projen.project.vue-component'
 import { LogLevel } from 'projen'
@@ -32,7 +29,6 @@ const monorepo = new ComponentsMonorepo({
 		'vitest',
 		'rollup-plugin-vue',
 		'tsx',
-		'unbuild',
 		'@types/prettier',
 		'fs-extra',
 		'@types/fs-extra',
@@ -40,7 +36,6 @@ const monorepo = new ComponentsMonorepo({
 		'@jsii/spec',
 		'ts-morph',
 		'@sindresorhus/is',
-		'eslint_d',
 		'pathe',
 	],
 })

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@typescript-eslint/parser": "^5",
     "@vitejs/plugin-vue": "^4.2.3",
     "eslint": "^8",
-    "eslint_d": "^12.2.1",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-node": "^0.3.7",
     "eslint-import-resolver-typescript": "^3.5.5",
@@ -95,7 +94,8 @@
       "wrap-ansi": "^7.0.0"
     },
     "patchedDependencies": {
-      "@mrgrain/jsii-struct-builder@0.4.3": "patches/@mrgrain__jsii-struct-builder@0.4.3.patch"
+      "@mrgrain/jsii-struct-builder@0.4.3": "patches/@mrgrain__jsii-struct-builder@0.4.3.patch",
+      "@aws-prototyping-sdk/nx-monorepo@0.18.16": "patches/@aws-prototyping-sdk__nx-monorepo@0.18.16.patch"
     }
   },
   "engines": {

--- a/packages/projen/component/pnpm-workspace/src/pnpm-workspace.ts
+++ b/packages/projen/component/pnpm-workspace/src/pnpm-workspace.ts
@@ -65,9 +65,11 @@ export class PnpmWorkspace extends Component {
 	 * @param patchPath Path to patch file.
 	 */
 	addPatch(dependency: string, patchPath: string): this {
-		this.project.package.file.addOverride('pnpm.patchedDependencies', {
-			[dependency]: patchPath,
-		})
+		const escapedName = dependency.replaceAll('.', '\\.')
+		this.project.package.file.addOverride(
+			`pnpm.patchedDependencies.${escapedName}`,
+			patchPath
+		)
 		const ncuFile = this.project.tryFindObjectFile('.ncurc.json')
 		if (ncuFile) {
 			ncuFile.addToArray('reject', dependency.split('@')[0])

--- a/packages/projen/component/tailwind/package.json
+++ b/packages/projen/component/tailwind/package.json
@@ -29,27 +29,27 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
-    "eslint-config-prettier": "*",
-    "eslint-import-resolver-node": "*",
-    "eslint-import-resolver-typescript": "*",
-    "eslint-plugin-import": "*",
-    "eslint-plugin-prettier": "*",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-import-resolver-node": "^0.3.7",
+    "eslint-import-resolver-typescript": "^3.5.5",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
     "npm-check-updates": "^16",
-    "prettier": "*",
-    "projen": "*",
+    "prettier": "^2.8.8",
+    "projen": "0.71.65",
     "standard-version": "^9",
     "typescript": "^5",
-    "unbuild": "*",
-    "vitest": "*"
+    "unbuild": "^1.2.1",
+    "vitest": "^0.31.1"
   },
   "peerDependencies": {
-    "projen": "*"
+    "projen": "^0.71.65"
   },
   "dependencies": {
     "@arroyodev-llc/projen.component.typescript-source-file": "workspace:*",
     "@arroyodev-llc/utils.projen": "workspace:*",
-    "tailwindcss": "*",
-    "ts-morph": "*"
+    "tailwindcss": "^3.3.2",
+    "ts-morph": "^18.0.0"
   },
   "pnpm": {},
   "main": "./dist/index.cjs",

--- a/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
@@ -195,7 +195,9 @@ export class MonorepoProject extends NxMonorepoProject {
 		if (!task) return this
 		// fix invalid install step.
 		const mergeUpdate = task.steps.map((step) =>
-			step.exec === 'pnpm exec install' ? { exec: 'pnpm install' } : undefined
+			step.exec === 'pnpm exec install'
+				? { exec: 'pnpm exec projen install' }
+				: undefined
 		) as TaskStep[]
 		replaceTask(this, task.name, mergeUpdate)
 		return this

--- a/patches/@aws-prototyping-sdk__nx-monorepo@0.18.16.patch
+++ b/patches/@aws-prototyping-sdk__nx-monorepo@0.18.16.patch
@@ -1,0 +1,66 @@
+diff --git a/lib/nx-monorepo.js b/lib/nx-monorepo.js
+index dd11ef99484f63534d91c9472602920cd2ccaaf5..8741cf4d756059fe8b2a5635c61c8f9431eea01b 100644
+--- a/lib/nx-monorepo.js
++++ b/lib/nx-monorepo.js
+@@ -370,33 +370,48 @@ class NxMonorepoProject extends typescript_1.TypeScriptProject {
+         // Prevent sub NodeProject packages from `postSynthesis` which will cause individual/extraneous installs.
+         // The workspace package install will handle all the sub NodeProject packages automatically.
+         const subProjectPackages = [];
++        this.subProjectResolves = [];
+         this.subprojects.forEach((subProject) => {
+             if (isNodeProject(subProject)) {
+                 const subNodeProject = subProject;
+-                subProjectPackages.push(subNodeProject.package);
++                subProjectPackages.push([subNodeProject.package, subNodeProject.package.resolveDepsAndWritePackageJson]);
++                const subNodeProjectResolver = subNodeProject.package.resolveDepsAndWritePackageJson
+                 // @ts-ignore - `installDependencies` is private
+-                subNodeProject.package.installDependencies = () => { };
++                subNodeProject.package.installDependencies = () => {
++                    this.logger.info(`${subNodeProject.name}: requested resolve/install`)
++                    this.subProjectResolves.push(() => {
++                        this.logger.info(`${subNodeProject.name}: resolve`)
++                        return subNodeProjectResolver.apply(subNodeProject.package)
++                    })
++                };
+                 // @ts-ignore - `resolveDepsAndWritePackageJson` is private
+                 subNodeProject.package.resolveDepsAndWritePackageJson = () => { };
+             }
+         });
+         super.synth();
+-        // Force workspace install deps if any node subproject package has changed, unless the workspace changed
+-        if (
+-        // @ts-ignore - `file` is private
+-        this.package.file.changed !== true &&
+-            // @ts-ignore - `file` is private
+-            subProjectPackages.find((pkg) => pkg.file.changed === true)) {
+-            try {
+-                // @ts-ignore - `installDependencies` is private
++    }
++
++    resolveSubProjects() {
++        if(this.subProjectResolves.length) {
++            if(!this.package.file.changed) {
++                this.logger.info('root installing deps due to no change')
+                 this.package.installDependencies();
+             }
+-            finally {
+-                // @ts-ignore - `resolveDepsAndWritePackageJson` is private
+-                this.package.resolveDepsAndWritePackageJson();
++            this.logger.info('resolving children:', this.subProjectResolves.length)
++            const completedResolves = this.subProjectResolves.map((resolve) => resolve())
++            this.logger.info('children resolve results:', completedResolves)
++            if(completedResolves.some(Boolean)) {
++                this.package.installDependencies()
+             }
++            this.subProjectResolves = [];
+         }
+     }
++
++    postSynthesize() {
++        super.postSynthesize();
++        this.resolveSubProjects();
++    }
++    
+     /**
+      * Ensures subprojects don't have a default task and that all packages use the same package manager.
+      */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,13 @@ lockfileVersion: '6.0'
 
 overrides:
   '@types/babel__traverse': 7.18.2
-  wrap-ansi: ^7.0.0
   '@zkochan/js-yaml': npm:js-yaml@4.1.0
+  wrap-ansi: ^7.0.0
 
 patchedDependencies:
+  '@aws-prototyping-sdk/nx-monorepo@0.18.16':
+    hash: vizkutn345nlltbrneqzzpermm
+    path: patches/@aws-prototyping-sdk__nx-monorepo@0.18.16.patch
   '@mrgrain/jsii-struct-builder@0.4.3':
     hash: 5n7l7qiehk4lghp47ostr53ckq
     path: patches/@mrgrain__jsii-struct-builder@0.4.3.patch
@@ -65,7 +68,7 @@ importers:
     devDependencies:
       '@aws-prototyping-sdk/nx-monorepo':
         specifier: ^0.18.16
-        version: 0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65)
+        version: 0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65)
       '@jsii/spec':
         specifier: ^1.81.0
         version: 1.81.0
@@ -111,9 +114,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.41.0)(prettier@2.8.8)
-      eslint_d:
-        specifier: ^12.2.1
-        version: 12.2.1
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -334,10 +334,10 @@ importers:
         specifier: workspace:*
         version: link:../../../utils/projen
       tailwindcss:
-        specifier: '*'
+        specifier: ^3.3.2
         version: 3.3.2(ts-node@10.9.1)
       ts-morph:
-        specifier: '*'
+        specifier: ^18.0.0
         version: 18.0.0
     devDependencies:
       '@types/node':
@@ -353,28 +353,28 @@ importers:
         specifier: ^8
         version: 8.41.0
       eslint-config-prettier:
-        specifier: '*'
+        specifier: ^8.8.0
         version: 8.8.0(eslint@8.41.0)
       eslint-import-resolver-node:
-        specifier: '*'
+        specifier: ^0.3.7
         version: 0.3.7
       eslint-import-resolver-typescript:
-        specifier: '*'
+        specifier: ^3.5.5
         version: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.41.0)
       eslint-plugin-import:
-        specifier: '*'
+        specifier: ^2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-prettier:
-        specifier: '*'
+        specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.41.0)(prettier@2.8.8)
       npm-check-updates:
         specifier: ^16
         version: 16.10.12
       prettier:
-        specifier: '*'
+        specifier: ^2.8.8
         version: 2.8.8
       projen:
-        specifier: '*'
+        specifier: 0.71.65
         version: 0.71.65
       standard-version:
         specifier: ^9
@@ -383,10 +383,10 @@ importers:
         specifier: ^5
         version: 5.0.4
       unbuild:
-        specifier: '*'
+        specifier: ^1.2.1
         version: 1.2.1
       vitest:
-        specifier: '*'
+        specifier: ^0.31.1
         version: 0.31.1(happy-dom@9.19.2)
 
   packages/projen/component/tool-versions:
@@ -495,7 +495,7 @@ importers:
         version: link:../../../utils/projen
       '@aws-prototyping-sdk/nx-monorepo':
         specifier: ^0.18.12
-        version: 0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65)
+        version: 0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65)
       ts-morph:
         specifier: ^18.0.0
         version: 18.0.0
@@ -556,7 +556,7 @@ importers:
         version: link:../../../utils/projen
       '@aws-prototyping-sdk/nx-monorepo':
         specifier: ^0.18.12
-        version: 0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65)
+        version: 0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65)
       ts-morph:
         specifier: ^18.0.0
         version: 18.0.0
@@ -824,7 +824,7 @@ importers:
         version: link:../../../utils/projen
       '@aws-prototyping-sdk/nx-monorepo':
         specifier: ^0.18.12
-        version: 0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65)
+        version: 0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65)
       '@mrgrain/jsii-struct-builder':
         specifier: '*'
         version: 0.4.3(patch_hash=5n7l7qiehk4lghp47ostr53ckq)(projen@0.71.65)
@@ -897,7 +897,7 @@ importers:
         version: link:../../../utils/projen
       '@aws-prototyping-sdk/nx-monorepo':
         specifier: '*'
-        version: 0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65)
+        version: 0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65)
     devDependencies:
       '@types/node':
         specifier: ^16
@@ -1267,7 +1267,7 @@ packages:
     resolution: {integrity: sha512-X7CjyphxMuAY1uNO2SMnTtQWxhnLf06ZAR9R4Ynm+8BOvyZfzqCrsmkT6O4nGRlhu5fGlRbNV//tCwU9e39yPQ==}
     dev: false
 
-  /@aws-prototyping-sdk/nx-monorepo@0.18.16(@pnpm/logger@5.0.0)(projen@0.71.65):
+  /@aws-prototyping-sdk/nx-monorepo@0.18.16(patch_hash=vizkutn345nlltbrneqzzpermm)(@pnpm/logger@5.0.0)(projen@0.71.65):
     resolution: {integrity: sha512-q2pBg6n+CwiuCNF+revwo6RR+d8viPgySGyED7JITLAbtQ7Ppc+epxQm0QlTKHKej6m3PtMaf7184ec2Kjs+oQ==}
     hasBin: true
     peerDependencies:
@@ -1283,6 +1283,7 @@ packages:
       - '@pnpm/reviewing.dependencies-hierarchy'
       - fs-extra
       - semver
+    patched: true
 
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
@@ -4170,12 +4171,6 @@ packages:
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /core_d@5.0.1:
-    resolution: {integrity: sha512-37lZyhJY1hzgFbfU4LzY4zL09QPwPfV2W/3YBOtN7mkdvVaeP1OVnDZI6zxggtlPwG/BuE5wIr0xptlVJk5EPA==}
-    dependencies:
-      supports-color: 8.1.1
-    dev: true
-
   /cosmiconfig@8.1.3:
     resolution: {integrity: sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==}
     engines: {node: '>=14'}
@@ -4820,18 +4815,6 @@ packages:
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint_d@12.2.1:
-    resolution: {integrity: sha512-qOJ9cTi5AaH5bOgEoCkv41DJ637mHgzffbOLojwU4wadwC6qbR+OxVJRvVzH0v2XYmQOvw4eiJK7ivrr5SvzsA==}
-    hasBin: true
-    dependencies:
-      core_d: 5.0.1
-      eslint: 8.41.0
-      nanolru: 1.0.0
-      optionator: 0.9.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6604,11 +6587,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /nanolru@1.0.0:
-    resolution: {integrity: sha512-GyQkE8M32pULhQk7Sko5raoIbPalAk90ICG+An4fq6fCsFHsP6fB2K46WGXVdoJpy4SGMnZ/EKbo123fZJomWg==}
-    engines: {node: '>= 0.4.0'}
-    dev: true
-
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -8225,13 +8203,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-
-  /supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/projenrc/monorepo.ts
+++ b/projenrc/monorepo.ts
@@ -37,6 +37,10 @@ export class ComponentsMonorepo extends MonorepoProject {
 			'@mrgrain/jsii-struct-builder@0.4.3',
 			'patches/@mrgrain__jsii-struct-builder@0.4.3.patch'
 		)
+		this.pnpm.addPatch(
+			'@aws-prototyping-sdk/nx-monorepo@0.18.16',
+			'patches/@aws-prototyping-sdk__nx-monorepo@0.18.16.patch'
+		)
 	}
 
 	protected applyNx(): this {


### PR DESCRIPTION
- fix(projen.component.pnpm-workspace): multiple patches overwrite each other
- fix(projen.project.component): correct `upgrade-deps` install step to run projen install task
- feat(deps): patch nx-monorepo to resolve subproject dependencies.
- chore(projenrc): update managed files

Fixes #
