### PR TITLE
feat: improve `post-install` hook / nx integration

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -164,13 +164,23 @@
       "name": "post-install",
       "steps": [
         {
-          "exec": "pnpm exec projen stub"
+          "exec": "pnpm exec nx run-many --target=post-install --output-style=stream --nx-bail",
+          "receiveArgs": true
         }
       ]
     },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
+    },
+    "postinstall": {
+      "name": "postinstall",
+      "description": "Post install hook.",
+      "steps": [
+        {
+          "exec": "pnpm exec projen post-install"
+        }
+      ]
     },
     "pre-compile": {
       "name": "pre-compile",
@@ -188,15 +198,6 @@
       "steps": [
         {
           "exec": "pnpm exec nx run-many",
-          "receiveArgs": true
-        }
-      ]
-    },
-    "stub": {
-      "name": "stub",
-      "steps": [
-        {
-          "exec": "pnpm exec nx run-many --target=stub --output-style=stream --parallel=5 --skip-nx-cache --nx-ignore-cycles",
           "receiveArgs": true
         }
       ]

--- a/package.json
+++ b/package.json
@@ -14,16 +14,15 @@
     "post-compile": "pnpm exec projen post-compile",
     "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
+    "postinstall": "pnpm exec projen postinstall",
     "pre-compile": "pnpm exec projen pre-compile",
     "run-many": "pnpm exec projen run-many",
-    "stub": "pnpm exec projen stub",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "upgrade": "pnpm exec projen upgrade",
     "upgrade-deps": "pnpm exec projen upgrade-deps",
     "watch": "pnpm exec projen watch",
-    "synth-workspace": "pnpm exec projen",
-    "postinstall": "pnpm exec projen post-install"
+    "synth-workspace": "pnpm exec projen"
   },
   "author": {
     "name": "arroyoDev-LLC",

--- a/packages/projen/component/dir-env/.projen/tasks.json
+++ b/packages/projen/component/dir-env/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/dir-env/package.json
+++ b/packages/projen/component/dir-env/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/dir-env/project.json
+++ b/packages/projen/component/dir-env/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/dir-env"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/dir-env"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/linting/.projen/tasks.json
+++ b/packages/projen/component/linting/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/linting/package.json
+++ b/packages/projen/component/linting/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/linting/project.json
+++ b/packages/projen/component/linting/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/linting"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/linting"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/pnpm-workspace/.projen/tasks.json
+++ b/packages/projen/component/pnpm-workspace/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/pnpm-workspace/package.json
+++ b/packages/projen/component/pnpm-workspace/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/pnpm-workspace/project.json
+++ b/packages/projen/component/pnpm-workspace/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/pnpm-workspace"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/pnpm-workspace"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/postcss/.projen/tasks.json
+++ b/packages/projen/component/postcss/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/postcss/package.json
+++ b/packages/projen/component/postcss/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/postcss/project.json
+++ b/packages/projen/component/postcss/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/postcss"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/postcss"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/release-please/.projen/tasks.json
+++ b/packages/projen/component/release-please/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/release-please/package.json
+++ b/packages/projen/component/release-please/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/release-please/project.json
+++ b/packages/projen/component/release-please/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/release-please"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/release-please"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/tailwind/.projen/tasks.json
+++ b/packages/projen/component/tailwind/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/tailwind/package.json
+++ b/packages/projen/component/tailwind/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/tailwind/project.json
+++ b/packages/projen/component/tailwind/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/tailwind"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/tailwind"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/tool-versions/.projen/tasks.json
+++ b/packages/projen/component/tool-versions/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/tool-versions/package.json
+++ b/packages/projen/component/tool-versions/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/tool-versions/project.json
+++ b/packages/projen/component/tool-versions/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/tool-versions"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/tool-versions"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/tsconfig-container/.projen/tasks.json
+++ b/packages/projen/component/tsconfig-container/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/tsconfig-container/package.json
+++ b/packages/projen/component/tsconfig-container/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/tsconfig-container/project.json
+++ b/packages/projen/component/tsconfig-container/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/tsconfig-container"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/tsconfig-container"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/typescript-source-file/.projen/tasks.json
+++ b/packages/projen/component/typescript-source-file/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/typescript-source-file/package.json
+++ b/packages/projen/component/typescript-source-file/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/typescript-source-file/project.json
+++ b/packages/projen/component/typescript-source-file/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/typescript-source-file"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/typescript-source-file"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/unbuild/.projen/tasks.json
+++ b/packages/projen/component/unbuild/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/unbuild/package.json
+++ b/packages/projen/component/unbuild/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/unbuild/project.json
+++ b/packages/projen/component/unbuild/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/unbuild"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/unbuild"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/unbuild/src/unbuild.ts
+++ b/packages/projen/component/unbuild/src/unbuild.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { TypeScriptSourceConfig } from '@arroyodev-llc/projen.component.typescript-source-file'
 import { cwdRelativePath } from '@arroyodev-llc/utils.projen'
 import { type ObjectLiteralMergeSchema } from '@arroyodev-llc/utils.ts-ast'
+import { NodePackageUtils } from '@aws-prototyping-sdk/nx-monorepo'
 import { Component, DependencyType } from 'projen'
 import { type TypeScriptProject } from 'projen/lib/typescript'
 import { type BuildConfig as UnBuildBuildConfig } from 'unbuild'
@@ -38,8 +39,16 @@ export class UnBuild extends Component {
 
 		const stubTask = this.project.addTask('stub', {
 			condition: 'test -z "$CI"',
+			exec: NodePackageUtils.command.exec(
+				project.package.packageManager,
+				'unbuild',
+				'--stub'
+			),
 		})
-		stubTask.exec('unbuild --stub')
+		const postInstall =
+			this.project.tasks.tryFind('post-install') ??
+			this.project.tasks.addTask('post-install')
+		postInstall.spawn(stubTask)
 
 		const exportInfo = this.buildExportInfo()
 		this.project.package.addField('module', exportInfo.import)

--- a/packages/projen/component/vite/.projen/tasks.json
+++ b/packages/projen/component/vite/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/vite/package.json
+++ b/packages/projen/component/vite/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/vite/project.json
+++ b/packages/projen/component/vite/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/vite"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/vite"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/vitest/.projen/tasks.json
+++ b/packages/projen/component/vitest/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/vitest/package.json
+++ b/packages/projen/component/vitest/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/vitest/project.json
+++ b/packages/projen/component/vitest/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/vitest"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/vitest"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/component/vue/.projen/tasks.json
+++ b/packages/projen/component/vue/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/component/vue/package.json
+++ b/packages/projen/component/vue/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/component/vue/project.json
+++ b/packages/projen/component/vue/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/component/vue"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/component/vue"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/project/nx-monorepo/.projen/tasks.json
+++ b/packages/projen/project/nx-monorepo/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/project/nx-monorepo/package.json
+++ b/packages/projen/project/nx-monorepo/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/project/nx-monorepo/project.json
+++ b/packages/projen/project/nx-monorepo/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/project/nx-monorepo"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/project/nx-monorepo"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/projen/project/nx-monorepo/src/nx-monorepo.ts
@@ -334,25 +334,23 @@ export class MonorepoProject extends NxMonorepoProject {
 				{ immediate: false, includeSelf: true }
 			)
 		}
-		this.addNxRunManyTask('stub', {
-			skipCache: true,
-			target: 'stub',
-			parallel: 5,
-			noBail: true,
-			ignoreCycles: true,
-			outputStyle: 'stream',
+
+		this.addNxRunManyTask('post-install', {
+			target: 'post-install',
 		})
+		// 'postinstall' is intentional here,
+		// as that is the name of the npm hook.
 		const postInstall =
-			this.tasks.tryFind('post-install') ?? this.tasks.addTask('post-install')
+			this.tasks.tryFind('postinstall') ??
+			this.addTask('postinstall', {
+				description: 'Post install hook.',
+			})
 		postInstall.exec(
-			NodePackageUtils.command.projen(this.package.packageManager, 'stub')
-		)
-		this.addScripts({
-			postinstall: NodePackageUtils.command.projen(
+			NodePackageUtils.command.projen(
 				this.package.packageManager,
 				'post-install'
-			),
-		})
+			)
+		)
 		return this
 	}
 

--- a/packages/projen/project/typescript/.projen/tasks.json
+++ b/packages/projen/project/typescript/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/project/typescript/package.json
+++ b/packages/projen/project/typescript/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/project/typescript/project.json
+++ b/packages/projen/project/typescript/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/project/typescript"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/project/typescript"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/projen/project/typescript/src/typescript.ts
+++ b/packages/projen/project/typescript/src/typescript.ts
@@ -214,4 +214,12 @@ export class TypescriptProject extends typescript.TypeScriptProject {
 	addWorkspaceDeps(...dependency: (javascript.NodeProject | string)[]) {
 		return PnpmWorkspace.of(this)!.addWorkspaceDeps(...dependency)
 	}
+
+	/**
+	 * Format executable command with project package manager.
+	 * @param args command args.
+	 */
+	formatExecCommand(...args: string[]): string {
+		return NodePackageUtils.command.exec(this.package.packageManager, ...args)
+	}
 }

--- a/packages/projen/project/vue-component/.projen/tasks.json
+++ b/packages/projen/project/vue-component/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/projen/project/vue-component/package.json
+++ b/packages/projen/project/vue-component/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/projen/project/vue-component/project.json
+++ b/packages/projen/project/vue-component/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/projen/project/vue-component"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/projen/project/vue-component"
+      }
+    },
     "clean": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/utils/fs/.projen/tasks.json
+++ b/packages/utils/fs/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/utils/fs/package.json
+++ b/packages/utils/fs/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/utils/fs/project.json
+++ b/packages/utils/fs/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/utils/fs"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/utils/fs"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/utils/projen/.projen/tasks.json
+++ b/packages/utils/projen/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/utils/projen/package.json
+++ b/packages/utils/projen/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/utils/projen/project.json
+++ b/packages/utils/projen/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/utils/projen"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/utils/projen"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/utils/ts-ast/.projen/tasks.json
+++ b/packages/utils/ts-ast/.projen/tasks.json
@@ -103,6 +103,14 @@
         }
       ]
     },
+    "post-install": {
+      "name": "post-install",
+      "steps": [
+        {
+          "spawn": "stub"
+        }
+      ]
+    },
     "post-upgrade": {
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
@@ -139,7 +147,7 @@
       "name": "stub",
       "steps": [
         {
-          "exec": "unbuild --stub"
+          "exec": "pnpm exec unbuild --stub"
         }
       ],
       "condition": "test -z \"$CI\""

--- a/packages/utils/ts-ast/package.json
+++ b/packages/utils/ts-ast/package.json
@@ -9,6 +9,7 @@
     "eslint": "pnpm exec projen eslint",
     "package": "pnpm exec projen package",
     "post-compile": "pnpm exec projen post-compile",
+    "post-install": "pnpm exec projen post-install",
     "post-upgrade": "pnpm exec projen post-upgrade",
     "pre-compile": "pnpm exec projen pre-compile",
     "release": "pnpm exec projen release",

--- a/packages/utils/ts-ast/project.json
+++ b/packages/utils/ts-ast/project.json
@@ -107,6 +107,13 @@
         "cwd": "packages/utils/ts-ast"
       }
     },
+    "post-install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen post-install",
+        "cwd": "packages/utils/ts-ast"
+      }
+    },
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
- feat(projen.project.nx-monorepo): setup `post-install` nx task, hook using `postinstall`
- feat(projen.project.typescript): `formatExecCommand` helper
- feat(projen.component.unbuild): hook `stub` task into `post-install` task

Fixes #
