### PR TITLE
feat(projen.project.typescript): `AwsCdkTs` base builders, CDK + LintStaged builder steps

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -269,6 +269,7 @@ const typescriptProject = ProjenComponentProjectBuilder.build({
 		releasePleaseComponent,
 		tsconfigContainerComponent,
 		nxMonorepoProject,
+		gitHooksComponent,
 	],
 })
 typescriptProject.lintConfig.eslint.addIgnorePattern(

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -42,7 +42,9 @@ const monorepo = new ComponentsMonorepo({
 		'pathe',
 	],
 })
-monorepo.package.addPackageResolutions('projen@0.73.31')
+monorepo.package.addPackageResolutions(
+	`projen@${monorepo.options.projenVersion!}`,
+)
 
 // Builders
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
     "fs-extra": "^11.1.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16.14.6",
     "nx": "16.0.0",
     "nx-cloud": "^16.5.2",

--- a/packages/projen/component/dir-env/package.json
+++ b/packages/projen/component/dir-env/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/git-hooks/package.json
+++ b/packages/projen/component/git-hooks/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/linting/package.json
+++ b/packages/projen/component/linting/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/pnpm-workspace/package.json
+++ b/packages/projen/component/pnpm-workspace/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/postcss/package.json
+++ b/packages/projen/component/postcss/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/release-please/package.json
+++ b/packages/projen/component/release-please/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/tailwind/package.json
+++ b/packages/projen/component/tailwind/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/tool-versions/package.json
+++ b/packages/projen/component/tool-versions/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/tsconfig-container/package.json
+++ b/packages/projen/component/tsconfig-container/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/typescript-source-file/package.json
+++ b/packages/projen/component/typescript-source-file/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/unbuild/package.json
+++ b/packages/projen/component/unbuild/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/vite/package.json
+++ b/packages/projen/component/vite/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/vitest/package.json
+++ b/packages/projen/component/vitest/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/component/vue/package.json
+++ b/packages/projen/component/vue/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/project/nx-monorepo/package.json
+++ b/packages/projen/project/nx-monorepo/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/project/typescript/.projen/deps.json
+++ b/packages/projen/project/typescript/.projen/deps.json
@@ -88,6 +88,11 @@
       "type": "peer"
     },
     {
+      "name": "@arroyodev-llc/projen.component.git-hooks",
+      "version": "workspace:*",
+      "type": "runtime"
+    },
+    {
       "name": "@arroyodev-llc/projen.component.linting",
       "version": "workspace:*",
       "type": "runtime"

--- a/packages/projen/project/typescript/package.json
+++ b/packages/projen/project/typescript/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/projen/project/typescript/package.json
+++ b/packages/projen/project/typescript/package.json
@@ -50,6 +50,7 @@
     "projen": "^0.76.0"
   },
   "dependencies": {
+    "@arroyodev-llc/projen.component.git-hooks": "workspace:*",
     "@arroyodev-llc/projen.component.linting": "workspace:*",
     "@arroyodev-llc/projen.component.pnpm-workspace": "workspace:*",
     "@arroyodev-llc/projen.component.release-please": "workspace:*",

--- a/packages/projen/project/typescript/src/typescript.ts
+++ b/packages/projen/project/typescript/src/typescript.ts
@@ -17,6 +17,7 @@ import {
 } from '@arroyodev-llc/utils.projen-builder'
 import { NodePackageUtils } from '@aws/pdk/monorepo'
 import {
+	awscdk,
 	type Component,
 	DependencyType,
 	javascript,
@@ -54,6 +55,16 @@ export const CONFIG_DEFAULTS = {
 	unbuild: true,
 } satisfies Omit<TypeScriptProjectOptions, 'name'>
 
+const BaseTSConfigBuilder = new tsBuilders.TypescriptConfigBuilder({
+	extendsDefault: (container) =>
+		container.buildExtends(
+			TSConfig.BASE,
+			TSConfig.ESM,
+			TSConfig.BUNDLER,
+			TSConfig.COMPOSITE,
+		),
+})
+
 /**
  * Base {@link typescript.TypeScriptProject} builder with most commonly used steps.
  */
@@ -61,21 +72,36 @@ export const TypescriptBaseBuilder = new ProjectBuilder(
 	typescript.TypeScriptProject,
 )
 	.add(new stdBuilders.DefaultOptionsBuilder(CONFIG_DEFAULTS))
-	.add(
-		new tsBuilders.TypescriptConfigBuilder({
-			extendsDefault: (container) =>
-				container.buildExtends(
-					TSConfig.BASE,
-					TSConfig.ESM,
-					TSConfig.BUNDLER,
-					TSConfig.COMPOSITE,
-				),
-		}),
-	)
+	.add(BaseTSConfigBuilder)
 	.add(new tsBuilders.TypescriptLintingBuilder({ useTypeInformation: true }))
 	.add(new tsBuilders.TypescriptESMManifestBuilder())
 	.add(new tsBuilders.TypescriptBundlerBuilder())
 	.add(new tsBuilders.TypescriptReleasePleaseBuilder())
+
+/**
+ * Base {@link awscdk.AwsCdkConstructLibrary} builder with most commonly used steps.
+ */
+export const AwsCdkTsConstructBaseBuilder = new ProjectBuilder(
+	awscdk.AwsCdkConstructLibrary,
+)
+	.add(new stdBuilders.DefaultOptionsBuilder(CONFIG_DEFAULTS))
+	.add(BaseTSConfigBuilder)
+	.add(new tsBuilders.TypescriptLintingBuilder({ useTypeInformation: true }))
+	.add(new tsBuilders.TypescriptESMManifestBuilder())
+	.add(new tsBuilders.TypescriptBundlerBuilder())
+	.add(new tsBuilders.TypescriptReleasePleaseBuilder())
+
+/**
+ * Base {@link awscdk} builder with most commonly used steps.
+ */
+export const AwsCdkTsAppBaseBuilder = new ProjectBuilder(
+	awscdk.AwsCdkTypeScriptApp,
+)
+	.add(new stdBuilders.DefaultOptionsBuilder(CONFIG_DEFAULTS))
+	.add(BaseTSConfigBuilder)
+	.add(new tsBuilders.TypescriptLintingBuilder({ useTypeInformation: true }))
+	.add(new tsBuilders.TypescriptESMManifestBuilder({ sideEffects: true }))
+	.add(new tsBuilders.TypescriptBundlerBuilder())
 
 /**
  * @deprecated Use `TypescriptBaseBuilder` instead

--- a/packages/projen/project/typescript/tsconfig.json
+++ b/packages/projen/project/typescript/tsconfig.json
@@ -47,6 +47,9 @@
     },
     {
       "path": "../nx-monorepo/tsconfig.json"
+    },
+    {
+      "path": "../../component/git-hooks/tsconfig.json"
     }
   ]
 }

--- a/packages/projen/project/vue-component/package.json
+++ b/packages/projen/project/vue-component/package.json
@@ -39,7 +39,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "projen": "0.76.0",

--- a/packages/utils/fs/package.json
+++ b/packages/utils/fs/package.json
@@ -38,7 +38,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/utils/projen-builder/package.json
+++ b/packages/utils/projen-builder/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/utils/projen/package.json
+++ b/packages/utils/projen/package.json
@@ -38,7 +38,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/utils/ts-ast/package.json
+++ b/packages/utils/ts-ast/package.json
@@ -37,7 +37,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/utils/unbuild-composite-preset/package.json
+++ b/packages/utils/unbuild-composite-preset/package.json
@@ -35,7 +35,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/vue/ui/button/package.json
+++ b/packages/vue/ui/button/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-vue": "^9.17.0",
     "faker": "^6.6.6",
     "happy-dom": "^10.11.2",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/packages/vue/ui/text/package.json
+++ b/packages/vue/ui/text/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-vue": "^9.17.0",
     "faker": "^6.6.6",
     "happy-dom": "^10.11.2",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.0.2",
     "npm-check-updates": "^16",
     "prettier": "^3.0.3",
     "standard-version": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16.14.6
         version: 16.14.6
@@ -219,8 +219,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -276,8 +276,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -346,8 +346,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -404,8 +404,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -438,7 +438,7 @@ importers:
         version: link:../../../utils/ts-ast
       postcss-load-config:
         specifier: ^4.0.1
-        version: 4.0.1(postcss@8.4.30)(ts-node@10.9.1)
+        version: 4.0.1(ts-node@10.9.1)
       ts-morph:
         specifier: ^19.0.0
         version: 19.0.0
@@ -474,8 +474,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -535,8 +535,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -605,8 +605,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -662,8 +662,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -720,8 +720,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -764,7 +764,7 @@ importers:
         version: link:../../../utils/unbuild-composite-preset
       '@aws/pdk':
         specifier: 0.22.6
-        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.167)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
+        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.170)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
       '@types/node':
         specifier: ^16
         version: 16.18.44
@@ -793,8 +793,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -837,7 +837,7 @@ importers:
         version: link:../../../utils/unbuild-composite-preset
       '@aws/pdk':
         specifier: 0.22.6
-        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.167)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
+        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.170)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
       '@types/node':
         specifier: ^16
         version: 16.18.44
@@ -866,8 +866,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -942,8 +942,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1018,8 +1018,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1094,8 +1094,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1138,7 +1138,7 @@ importers:
         version: link:../../../utils/unbuild-composite-preset
       '@aws/pdk':
         specifier: 0.22.6
-        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.167)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
+        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.170)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
       '@types/node':
         specifier: ^16
         version: 16.18.44
@@ -1167,8 +1167,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1226,7 +1226,7 @@ importers:
         version: link:../../../utils/unbuild-composite-preset
       '@aws/pdk':
         specifier: 0.22.6
-        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.167)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
+        version: 0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.170)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6)
       '@types/node':
         specifier: ^16
         version: 16.18.44
@@ -1255,8 +1255,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1331,8 +1331,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1395,8 +1395,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1468,8 +1468,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1532,8 +1532,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1605,8 +1605,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1656,8 +1656,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1735,8 +1735,8 @@ importers:
         specifier: ^10.11.2
         version: 10.11.2
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1823,8 +1823,8 @@ importers:
         specifier: ^10.11.2
         version: 10.11.2
       lint-staged:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.2
+        version: 15.0.2
       npm-check-updates:
         specifier: ^16
         version: 16.14.4
@@ -1922,7 +1922,7 @@ packages:
       constructs: 10.3.0
     dev: true
 
-  /@aws/pdk@0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.167)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6):
+  /@aws/pdk@0.22.6(@aws-cdk/aws-cognito-identitypool-alpha@2.93.0-alpha.0)(@pnpm/logger@5.0.0)(@types/node@16.18.44)(aws-cdk-lib@2.102.0)(cdk-nag@2.27.170)(constructs@10.3.0)(projen@0.73.31)(typescript@5.1.6):
     resolution:
       {
         integrity: sha512-vMsLcfT0qf4yUsqdK/G1xFJGj8UnOkUHWy+0Ksz7qzXenUv9K574zwneMDSQwlQXa1nt4o72O5SJCuDiFIAdLA==,
@@ -1939,7 +1939,7 @@ packages:
       '@hpcc-js/wasm': 2.14.0
       '@pnpm/reviewing.dependencies-hierarchy': 2.0.11(@pnpm/logger@5.0.0)
       aws-cdk-lib: 2.102.0(constructs@10.3.0)
-      cdk-nag: 2.27.167(aws-cdk-lib@2.102.0)(constructs@10.3.0)
+      cdk-nag: 2.27.170(aws-cdk-lib@2.102.0)(constructs@10.3.0)
       chalk: 4.1.2
       constructs: 10.3.0
       execa: 5.1.1
@@ -5876,6 +5876,19 @@ packages:
       aws-cdk-lib: 2.102.0(constructs@10.3.0)
       constructs: 10.3.0
 
+  /cdk-nag@2.27.170(aws-cdk-lib@2.102.0)(constructs@10.3.0):
+    resolution:
+      {
+        integrity: sha512-vk4PsB6R+RKudEG2DO7ylr4aGCPeJabFMsVo3+iNv0mRyaIo+MlVdGCqHlfjaYq94L9MknnwSeEPpY7Q7jNT+g==,
+      }
+    peerDependencies:
+      aws-cdk-lib: ^2.78.0
+      constructs: ^10.0.5
+    dependencies:
+      aws-cdk-lib: 2.102.0(constructs@10.3.0)
+      constructs: 10.3.0
+    dev: true
+
   /chai@4.3.10:
     resolution:
       {
@@ -6191,6 +6204,14 @@ packages:
     resolution:
       {
         integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==,
+      }
+    engines: { node: '>=16' }
+    dev: true
+
+  /commander@11.1.0:
+    resolution:
+      {
+        integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
       }
     engines: { node: '>=16' }
     dev: true
@@ -7584,6 +7605,24 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
+  /execa@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==,
+      }
+    engines: { node: '>=16.17' }
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: true
+
   /expand-template@2.0.3:
     resolution:
       {
@@ -8071,6 +8110,14 @@ packages:
         integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
       }
     engines: { node: '>=10' }
+    dev: true
+
+  /get-stream@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==,
+      }
+    engines: { node: '>=16' }
     dev: true
 
   /get-symbol-description@1.0.0:
@@ -8619,6 +8666,14 @@ packages:
         integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==,
       }
     engines: { node: '>=14.18.0' }
+    dev: true
+
+  /human-signals@5.0.0:
+    resolution:
+      {
+        integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==,
+      }
+    engines: { node: '>=16.17.0' }
     dev: true
 
   /humanize-ms@1.2.1:
@@ -9495,40 +9550,34 @@ packages:
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     dev: true
 
-  /lint-staged@14.0.1:
+  /lint-staged@15.0.2:
     resolution:
       {
-        integrity: sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==,
+        integrity: sha512-vnEy7pFTHyVuDmCAIFKR5QDO8XLVlPFQQyujQ/STOxe40ICWqJ6knS2wSJ/ffX/Lw0rz83luRDh+ET7toN+rOw==,
       }
-    engines: { node: ^16.14.0 || >=18.0.0 }
+    engines: { node: '>=18.12.0' }
     hasBin: true
     dependencies:
       chalk: 5.3.0
-      commander: 11.0.0
+      commander: 11.1.0
       debug: 4.3.4
-      execa: 7.2.0
+      execa: 8.0.1
       lilconfig: 2.1.0
-      listr2: 6.6.1
+      listr2: 7.0.2
       micromatch: 4.0.5
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.3.1
+      yaml: 2.3.3
     transitivePeerDependencies:
-      - enquirer
       - supports-color
     dev: true
 
-  /listr2@6.6.1:
+  /listr2@7.0.2:
     resolution:
       {
-        integrity: sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==,
+        integrity: sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==,
       }
     engines: { node: '>=16.0.0' }
-    peerDependencies:
-      enquirer: '>= 2.3.0 < 3'
-    peerDependenciesMeta:
-      enquirer:
-        optional: true
     dependencies:
       cli-truncate: 3.1.0
       colorette: 2.0.20
@@ -11425,6 +11474,26 @@ packages:
       lilconfig: 2.1.0
       postcss: 8.4.30
       ts-node: 10.9.1(@types/node@18.17.9)(typescript@5.1.6)
+      yaml: 2.3.3
+    dev: false
+
+  /postcss-load-config@4.0.1(ts-node@10.9.1):
+    resolution:
+      {
+        integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==,
+      }
+    engines: { node: '>= 14' }
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      ts-node: 10.9.1(@types/node@18.17.9)(typescript@5.1.6)
       yaml: 2.3.1
     dev: false
 
@@ -12469,6 +12538,14 @@ packages:
     resolution:
       {
         integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==,
+      }
+    engines: { node: '>=14' }
+    dev: true
+
+  /signal-exit@4.1.0:
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
     engines: { node: '>=14' }
     dev: true
@@ -14547,7 +14624,7 @@ packages:
     engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
     dependencies:
       imurmurhash: 0.1.4
-      signal-exit: 4.0.2
+      signal-exit: 4.1.0
     dev: true
 
   /write-yaml-file@5.0.0:
@@ -14646,6 +14723,13 @@ packages:
     resolution:
       {
         integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==,
+      }
+    engines: { node: '>= 14' }
+
+  /yaml@2.3.3:
+    resolution:
+      {
+        integrity: sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==,
       }
     engines: { node: '>= 14' }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1190,6 +1190,9 @@ importers:
 
   packages/projen/project/typescript:
     dependencies:
+      '@arroyodev-llc/projen.component.git-hooks':
+        specifier: workspace:*
+        version: link:../../component/git-hooks
       '@arroyodev-llc/projen.component.linting':
         specifier: workspace:*
         version: link:../../component/linting
@@ -2885,6 +2888,12 @@ packages:
     engines: { node: '>=6.9.0' }
     dev: true
 
+  /@iarna/toml@2.2.5:
+    resolution:
+      {
+        integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==,
+      }
+
   /@isaacs/cliui@8.0.2:
     resolution:
       {
@@ -3275,6 +3284,43 @@ packages:
         integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==,
       }
     dev: true
+
+  /@oozcitak/dom@1.15.10:
+    resolution:
+      {
+        integrity: sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==,
+      }
+    engines: { node: '>=8.0' }
+    dependencies:
+      '@oozcitak/infra': 1.0.8
+      '@oozcitak/url': 1.0.4
+      '@oozcitak/util': 8.3.8
+
+  /@oozcitak/infra@1.0.8:
+    resolution:
+      {
+        integrity: sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==,
+      }
+    engines: { node: '>=6.0' }
+    dependencies:
+      '@oozcitak/util': 8.3.8
+
+  /@oozcitak/url@1.0.4:
+    resolution:
+      {
+        integrity: sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==,
+      }
+    engines: { node: '>=8.0' }
+    dependencies:
+      '@oozcitak/infra': 1.0.8
+      '@oozcitak/util': 8.3.8
+
+  /@oozcitak/util@8.3.8:
+    resolution:
+      {
+        integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==,
+      }
+    engines: { node: '>=8.0' }
 
   /@parcel/watcher@2.0.4:
     resolution:
@@ -5274,7 +5320,6 @@ packages:
       }
     dependencies:
       sprintf-js: 1.0.3
-    dev: true
 
   /argparse@2.0.1:
     resolution:
@@ -5313,6 +5358,12 @@ packages:
       get-intrinsic: 1.2.1
       is-string: 1.0.7
     dev: true
+
+  /array-timsort@1.0.3:
+    resolution:
+      {
+        integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==,
+      }
 
   /array-union@2.1.0:
     resolution:
@@ -5860,7 +5911,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chalk@5.3.0:
     resolution:
@@ -6021,7 +6071,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: true
 
   /clone@1.0.4:
     resolution:
@@ -6172,6 +6221,19 @@ packages:
     dev: true
     optional: true
 
+  /comment-json@4.2.2:
+    resolution:
+      {
+        integrity: sha512-H8T+kl3nZesZu41zO2oNXIJWojNeK3mHxCLrsBNu6feksBXsgb+PtYz5daP5P86A0F3sz3840KVYehr04enISQ==,
+      }
+    engines: { node: '>= 6' }
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
+
   /commondir@1.0.1:
     resolution:
       {
@@ -6296,7 +6358,6 @@ packages:
       {
         integrity: sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==,
       }
-    dev: true
 
   /conventional-changelog-conventionalcommits@4.6.3:
     resolution:
@@ -6487,7 +6548,6 @@ packages:
       {
         integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
       }
-    dev: true
 
   /cosmiconfig@8.2.0:
     resolution:
@@ -7425,7 +7485,6 @@ packages:
       }
     engines: { node: '>=4' }
     hasBin: true
-    dev: true
 
   /esquery@1.5.0:
     resolution:
@@ -7603,6 +7662,12 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+
+  /fast-json-patch@3.1.1:
+    resolution:
+      {
+        integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==,
+      }
 
   /fast-json-stable-stringify@2.1.0:
     resolution:
@@ -7951,7 +8016,6 @@ packages:
         integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
       }
     engines: { node: 6.* || 8.* || >= 10.* }
-    dev: true
 
   /get-func-name@2.0.2:
     resolution:
@@ -8171,7 +8235,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /glob@8.1.0:
     resolution:
@@ -8365,7 +8428,13 @@ packages:
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: '>=8' }
-    dev: true
+
+  /has-own-prop@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==,
+      }
+    engines: { node: '>=8' }
 
   /has-property-descriptors@1.0.0:
     resolution:
@@ -8665,7 +8734,6 @@ packages:
         integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==,
       }
     engines: { node: '>=10' }
-    dev: true
 
   /ini@4.1.1:
     resolution:
@@ -8686,6 +8754,13 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
+
+  /interpret@1.4.0:
+    resolution:
+      {
+        integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==,
+      }
+    engines: { node: '>= 0.10' }
 
   /ip@2.0.0:
     resolution:
@@ -9180,7 +9255,6 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: true
 
   /js-yaml@4.1.0:
     resolution:
@@ -10030,7 +10104,6 @@ packages:
       {
         integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
       }
-    dev: true
 
   /minipass-collect@1.0.2:
     resolution:
@@ -11515,6 +11588,20 @@ packages:
       }
     engines: { node: '>= 14.0.0' }
     hasBin: true
+    dependencies:
+      '@iarna/toml': 2.2.5
+      case: 1.6.3
+      chalk: 4.1.2
+      comment-json: 4.2.2
+      conventional-changelog-config-spec: 2.1.0
+      fast-json-patch: 3.1.1
+      glob: 8.1.0
+      ini: 2.0.0
+      semver: 7.5.4
+      shx: 0.3.4
+      xmlbuilder2: 3.1.1
+      yaml: 2.3.1
+      yargs: 17.7.2
     bundledDependencies:
       - '@iarna/toml'
       - case
@@ -11829,6 +11916,15 @@ packages:
     engines: { node: '>=10' }
     dev: true
 
+  /rechoir@0.6.2:
+    resolution:
+      {
+        integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==,
+      }
+    engines: { node: '>= 0.10' }
+    dependencies:
+      resolve: 1.22.4
+
   /redent@3.0.0:
     resolution:
       {
@@ -11895,13 +11991,19 @@ packages:
     engines: { node: '>= 0.8.0' }
     dev: true
 
+  /repeat-string@1.6.1:
+    resolution:
+      {
+        integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==,
+      }
+    engines: { node: '>=0.10' }
+
   /require-directory@2.1.1:
     resolution:
       {
         integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
       }
     engines: { node: '>=0.10.0' }
-    dev: true
 
   /require-from-string@2.0.2:
     resolution:
@@ -12297,6 +12399,18 @@ packages:
       }
     dev: false
 
+  /shelljs@0.8.5:
+    resolution:
+      {
+        integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==,
+      }
+    engines: { node: '>=4' }
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+
   /shiki@0.14.3:
     resolution:
       {
@@ -12315,6 +12429,17 @@ packages:
         integrity: sha512-oB8s64JsyJ2xhHJlnTwGg++Y3BTF6XnXeXMC7OygD8vtNcCRDiMxEGONvUOeZbxfwEXENmRlqPDouMR/OtGDsw==,
       }
     dev: true
+
+  /shx@0.3.4:
+    resolution:
+      {
+        integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==,
+      }
+    engines: { node: '>=6' }
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.8.5
 
   /side-channel@1.0.4:
     resolution:
@@ -12592,7 +12717,6 @@ packages:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
-    dev: true
 
   /ssri@10.0.5:
     resolution:
@@ -12896,7 +13020,6 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution:
@@ -14397,7 +14520,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrappy@1.0.2:
     resolution:
@@ -14474,6 +14596,18 @@ packages:
       xml-lexer: 0.2.2
     dev: true
 
+  /xmlbuilder2@3.1.1:
+    resolution:
+      {
+        integrity: sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==,
+      }
+    engines: { node: '>=12.0' }
+    dependencies:
+      '@oozcitak/dom': 1.15.10
+      '@oozcitak/infra': 1.0.8
+      '@oozcitak/util': 8.3.8
+      js-yaml: 3.14.1
+
   /xtend@4.0.2:
     resolution:
       {
@@ -14488,7 +14622,6 @@ packages:
         integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
       }
     engines: { node: '>=10' }
-    dev: true
 
   /yallist@3.1.1:
     resolution:
@@ -14530,7 +14663,6 @@ packages:
         integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
       }
     engines: { node: '>=12' }
-    dev: true
 
   /yargs@16.2.0:
     resolution:
@@ -14562,7 +14694,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
 
   /yn@3.1.1:
     resolution:


### PR DESCRIPTION
- feat(projenrc): use `projenVersion` from monorepo options for resolution
- feat(projen.project.typescript): implement base builders for AwsCdkTs constructs and apps
- feat(projen.project.typescript): implement `CdkTsAppCompileBuilder` build step
- feat(projen.project.typescript): add git-hooks component as dependency
- feat(projen.project.typescript): implement `TypescriptLintStagedHooksBuilder` build step
- feat(deps): upgrade lint-staged to latest

Fixes #
